### PR TITLE
Add new parameter `stakingEndView` to `resetEpoch`

### DIFF
--- a/templates/reset_epoch_with_end_staking_auction.cdc
+++ b/templates/reset_epoch_with_end_staking_auction.cdc
@@ -5,6 +5,7 @@ transaction(currentEpochCounter: UInt64,
             randomSource: String,
             newPayout: UFix64?,
             startView: UInt64,
+            stakingEndView: UInt64,
             endView: UInt64) {
 
     prepare(signer: AuthAccount) {
@@ -20,6 +21,7 @@ transaction(currentEpochCounter: UInt64,
                             randomSource: randomSource,
                              newPayout: newPayout,
                              startView: startView,
+                             stakingEndView: stakingEndView,
                              endView: endView,
                              collectorClusters: [],
                              clusterQCs: [],


### PR DESCRIPTION
Updates the `service-account` version of this script to be consistent with latest `flow-core-contracts` (eg. [flow-core-contracts script](https://github.com/onflow/flow-core-contracts/blob/master/transactions/epoch/admin/reset_epoch.cdc))