### PR TITLE
Create set_reward.cdc

### DIFF
--- a/templates/set_reward.cdc
+++ b/templates/set_reward.cdc
@@ -1,0 +1,11 @@
+import FlowEpoch from 0x8624b52f9ddcd04a
+
+transaction(newRewardAPY: UFix64) {
+    prepare(signer: AuthAccount) {
+
+        let epochAdmin = signer.borrow<&FlowEpoch.Admin>(from: FlowEpoch.adminStoragePath)
+            ?? panic("Could not borrow admin from storage path")
+
+        epochAdmin.updateFLOWSupplyIncreasePercentage(newRewardAPY)
+    }
+}


### PR DESCRIPTION
Add cadence script to update the reward APY for automatic rewards payouts. This needs to be set to `0.00093871` before using the new reward calculation code.