### PR TITLE
remove candidate limit change for approve list

### DIFF
--- a/templates/add_approved_id_list.cdc
+++ b/templates/add_approved_id_list.cdc
@@ -8,7 +8,7 @@ import FlowIDTableStaking from 0x8624b52f9ddcd04a
 /// If any of the provided nodes already exist in the ID table, this
 /// transaction will not revert (idempotent)
 
-transaction(ids: [String]) {
+transaction(newApprovedIDs: [String]) {
 
     // Local variable for a reference to the ID Table Admin object
     let adminRef: &FlowIDTableStaking.Admin
@@ -20,39 +20,29 @@ transaction(ids: [String]) {
     }
 
     execute {
-		let nodeIDs = FlowIDTableStaking.getApprovedList()
-
-		let candidateNodeLimits = FlowIDTableStaking.getCandidateNodeLimits()
-			?? panic("Could not load candidate node limits")
+		let existingApprovedIDs = FlowIDTableStaking.getApprovedList()
 
 		let slotLimits = FlowIDTableStaking.getRoleSlotLimits()
 
 		// add any new node ID which doesn't already exist in the approve list
 		// and increase the candidate node limits and slot limits by 1
 		// for each corresponding node added
-		for newNodeID in ids {
-			if nodeIDs[newNodeID] != nil {
+		for newNodeID in newApprovedIDs {
+			if existingApprovedIDs[newNodeID] != nil {
     			continue
 			}
 
 			let nodeInfo = FlowIDTableStaking.NodeInfo(newNodeID)
 
-			candidateNodeLimits[nodeInfo.role] = candidateNodeLimits[nodeInfo.role]! + 1
-
 			slotLimits[nodeInfo.role] = slotLimits[nodeInfo.role]! + 1
 
-			nodeIDs[newNodeID] = true
+			existingApprovedIDs[newNodeID] = true
 		}
 
 		// set the approved list to the union of existing and new node IDs
-        self.adminRef.setApprovedList(nodeIDs)
+        self.adminRef.setApprovedList(existingApprovedIDs)
 
 		// Set new slot limits
 		self.adminRef.setSlotLimits(slotLimits: slotLimits)
-
-		// Set new candidate node limits
-		for role in candidateNodeLimits.keys {
-			self.adminRef.setCandidateNodeLimit(role: role, newLimit: candidateNodeLimits[role]!)
-		}
     }
 }

--- a/templates/add_approved_id_list.cdc
+++ b/templates/add_approved_id_list.cdc
@@ -21,6 +21,7 @@ transaction(newApprovedIDs: [String]) {
 
     execute {
 		let existingApprovedIDs = FlowIDTableStaking.getApprovedList()
+			?? panic("Could not load approved list")
 
 		let slotLimits = FlowIDTableStaking.getRoleSlotLimits()
 


### PR DESCRIPTION
We decided to set the candidate node limit to a higher value by default, so there is no need to increase it every time we approve new nodes