### PR TITLE
Add Feb-27 transaction for approve list and slot limits

### DIFF
--- a/transactions/set-approved-id-list/2023/feb-27/README.md
+++ b/transactions/set-approved-id-list/2023/feb-27/README.md
@@ -1,0 +1,24 @@
+# Add Approved Node Operators and increase Access node Slot Limit
+
+> Feb 27th, 2023 
+
+1. Adds Two Consensus nodes for Blockdaemon, which will also automatically increase the slot limit for access nodes
+`5a4bff17941a73909472afe23f1ccdc59d7526f93b16b4e374bd8353f8b624b4`
+
+`d98755f4ae8bef3f372889c4d7010ca784ea6da46fdde63d27ee57b2bf5efdd7`
+
+2. Increases the slot limit for Access nodes to allow the one that was removed to be staked.
+
+## Using Multisign tool
+
+1. DapperLabs generates the Signature Request ID on the [site]() for the `add_approved_id_list_and_access_limits.cdc` transaction with the given args.
+
+2. Signers sign with the multisign tool specifying the Signature Request ID
+   `bash multisig.sh -f flow-staking.json <Signature Request ID>`
+
+3. Someone submits the transaction from the [site](https://flow-multisig-git-service-account-onflow.vercel.app/mainnet)
+
+
+## Results
+
+https://flowscan.org/transaction/

--- a/transactions/set-approved-id-list/2023/feb-27/add_approved_id_list_and_access_limits.cdc
+++ b/transactions/set-approved-id-list/2023/feb-27/add_approved_id_list_and_access_limits.cdc
@@ -46,7 +46,7 @@ transaction(newApprovedIDs: [String]) {
 		currentAccessSlotLimit = slotLimits[UInt8(5)]
 			?? panic("Could not get access node slot limit")
 
-		slotLimits[UInt8(5)] = currentAccessSlotLimit + 2
+		slotLimits[UInt8(5)] = currentAccessSlotLimit + 7
 
 		// Set new slot limits
 		self.adminRef.setSlotLimits(slotLimits: slotLimits)

--- a/transactions/set-approved-id-list/2023/feb-27/add_approved_id_list_and_access_limits.cdc
+++ b/transactions/set-approved-id-list/2023/feb-27/add_approved_id_list_and_access_limits.cdc
@@ -1,0 +1,54 @@
+import FlowIDTableStaking from 0x8624b52f9ddcd04a
+
+/// This transaction adds node IDs to the list of approved nodes in
+/// the ID table. 
+/// It also increases the candidate node limit and slot limits
+/// by the number of nodes who are added
+///
+/// If any of the provided nodes already exist in the ID table, this
+/// transaction will not revert (idempotent)
+
+transaction(newApprovedIDs: [String]) {
+
+    // Local variable for a reference to the ID Table Admin object
+    let adminRef: &FlowIDTableStaking.Admin
+
+    prepare(acct: AuthAccount) {
+        // borrow a reference to the admin object
+        self.adminRef = acct.borrow<&FlowIDTableStaking.Admin>(from: FlowIDTableStaking.StakingAdminStoragePath)
+            ?? panic("Could not borrow reference to staking admin")
+    }
+
+    execute {
+		let existingApprovedIDs = FlowIDTableStaking.getApprovedList()
+			?? panic("Could not load approved list")
+
+		let slotLimits = FlowIDTableStaking.getRoleSlotLimits()
+
+		// add any new node ID which doesn't already exist in the approve list
+		// and increase the candidate node limits and slot limits by 1
+		// for each corresponding node added
+		for newNodeID in newApprovedIDs {
+			if existingApprovedIDs[newNodeID] != nil {
+    			continue
+			}
+
+			let nodeInfo = FlowIDTableStaking.NodeInfo(newNodeID)
+
+			slotLimits[nodeInfo.role] = slotLimits[nodeInfo.role]! + 1
+
+			existingApprovedIDs[newNodeID] = true
+		}
+
+		// set the approved list to the union of existing and new node IDs
+        self.adminRef.setApprovedList(existingApprovedIDs)
+
+		currentAccessSlotLimit = slotLimits[UInt8(5)]
+			?? panic("Could not get access node slot limit")
+
+		slotLimits[UInt8(5)] = currentAccessSlotLimit + 2
+
+		// Set new slot limits
+		self.adminRef.setSlotLimits(slotLimits: slotLimits)
+    }
+}

--- a/transactions/set-approved-id-list/2023/feb-27/arguments.json
+++ b/transactions/set-approved-id-list/2023/feb-27/arguments.json
@@ -1,0 +1,15 @@
+[
+    {
+        "type": "Array",
+        "value": [
+            {
+                "type": "String",
+                "value": "5a4bff17941a73909472afe23f1ccdc59d7526f93b16b4e374bd8353f8b624b4"
+            },
+            {
+                "type": "String",
+                "value": "d98755f4ae8bef3f372889c4d7010ca784ea6da46fdde63d27ee57b2bf5efdd7"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Adds a transaction that will add the two blockdaemon consensus nodes to the approve list and increase the slot limits for access nodes by 2 so that the access node that was kicked out last epoch will be included in the upcoming epoch.

The access node will still have to stake 100 FLOW to be considered for the upcoming epoch.

We'll need to keep an eye out on the candidate node list for access nodes. This access node will still have to go through the slot selection process, so if the candidate node list grows larger than what we have set it as, they might not get included. We could potentially raise it higher to avoid this though.

This can be signed and submitted with the web tool method with the staking account