### PR TITLE
add change candidate limits script

### DIFF
--- a/templates/change_candidate_limits.cdc
+++ b/templates/change_candidate_limits.cdc
@@ -1,0 +1,21 @@
+import FlowIDTableStaking from 0x8624b52f9ddcd04a
+
+/// This transaction changes the limit of new nodes that can be candidates
+/// for the next epoch
+transaction(newCandidateNodeLimits: {UInt8: UInt64}) {
+
+    /// Local variable for a reference to the ID Table Admin object
+    let adminRef: &FlowIDTableStaking.Admin
+
+    prepare(acct: AuthAccount) {
+        // borrow a reference to the admin object
+        self.adminRef = acct.borrow<&FlowIDTableStaking.Admin>(from: FlowIDTableStaking.StakingAdminStoragePath)
+            ?? panic("Could not borrow reference to staking admin")
+    }
+
+    execute {
+        for role in newCandidateNodeLimits.keys {
+            self.adminRef.setCandidateNodeLimit(role: role, newLimit: newCandidateNodeLimits[role]!)
+        }
+    }
+}

--- a/templates/pay_rewards_move_tokens.cdc
+++ b/templates/pay_rewards_move_tokens.cdc
@@ -1,0 +1,30 @@
+import FlowIDTableStaking from 0x8624b52f9ddcd04a
+import FlowEpoch from 0x8624b52f9ddcd04a
+
+// This transaction uses a staking admin reference
+// to remove insufficiently staked nodes, pay rewards and move tokens between buckets.
+//
+// It also sets a new token payout for the next epoch
+
+transaction(newPayout: UFix64, nodeList: {String: UFix64}) {
+
+    // Local variable for a reference to the ID Table Admin object
+    let adminRef: &FlowIDTableStaking.Admin
+
+    prepare(acct: AuthAccount) {
+        self.adminRef = acct.borrow<&FlowIDTableStaking.Admin>(from: FlowIDTableStaking.StakingAdminStoragePath)
+            ?? panic("Could not borrow reference to staking admin")
+    }
+
+    execute {
+
+        self.adminRef.setNonOperationalNodesList(nodeList)
+
+        self.adminRef.
+
+        let rewardsArray = self.adminRef.calculateRewards()
+        self.adminRef.payRewards(rewardsArray)
+
+        self.adminRef.setEpochTokenPayout(newPayout)
+    }
+}

--- a/transactions/set-candidate-limits/2023/nov-3/README.md
+++ b/transactions/set-candidate-limits/2023/nov-3/README.md
@@ -1,0 +1,34 @@
+# Increase Candidate Node Limits for all non-access node types
+
+> November 3, 2023
+
+## Transactions
+
+1. Increase candidate node limits
+
+`templates/change_candidate_limits.cdc`
+___
+
+# Transaction 1
+
+## Transaction 1 Sequence of signing: 
+
+Signer: flow-staking
+Transaction: `templates/change_candidate_limits.cdc`
+Args: `arguments-change-candidate-limits.json`
+
+This transaction can be executed using the web tool.
+
+1. Flow generates the Signature Request ID on the [site](https://flow-multisig-git-service-account-onflow.vercel.app/mainnet?type=&name=&param=%5B%5D&acct=0x8624b52f9ddcd04a&limit=9999) for the `change_candidate_limits.cdc` transaction with the given args.
+
+2. Signers sign with the web tool or using flow cli specifying the Signature Request ID
+
+3. [Site](https://flow-multisig-git-service-account-onflow.vercel.app/mainnet) submits the transaction
+
+
+### Results
+
+Successful attempt:
+https://flowdiver.io/
+
+___

--- a/transactions/set-candidate-limits/2023/nov-3/arguments-change-candidate-limits.json
+++ b/transactions/set-candidate-limits/2023/nov-3/arguments-change-candidate-limits.json
@@ -9,7 +9,7 @@
                 },
                 "value": {
                     "type": "UInt64",
-                    "value": "100"
+                    "value": "200"
                 }
             },
             {
@@ -19,7 +19,7 @@
                 },
                 "value": {
                     "type": "UInt64",
-                    "value": "100"
+                    "value": "200"
                 }
             },
             {
@@ -29,7 +29,7 @@
                 },
                 "value": {
                     "type": "UInt64",
-                    "value": "20"
+                    "value": "10"
                 }
             },
             {

--- a/transactions/set-candidate-limits/2023/nov-3/arguments-change-candidate-limits.json
+++ b/transactions/set-candidate-limits/2023/nov-3/arguments-change-candidate-limits.json
@@ -1,0 +1,47 @@
+[
+    {
+        "type": "Dictionary",
+        "value": [
+            {
+                "key": {
+                    "type": "UInt8",
+                    "value": "1"
+                },
+                "value": {
+                    "type": "UInt64",
+                    "value": "100"
+                }
+            },
+            {
+                "key": {
+                    "type": "UInt8",
+                    "value": "2"
+                },
+                "value": {
+                    "type": "UInt64",
+                    "value": "100"
+                }
+            },
+            {
+                "key": {
+                    "type": "UInt8",
+                    "value": "3"
+                },
+                "value": {
+                    "type": "UInt64",
+                    "value": "20"
+                }
+            },
+            {
+                "key": {
+                    "type": "UInt8",
+                    "value": "4"
+                },
+                "value": {
+                    "type": "UInt64",
+                    "value": "200"
+                }
+            }
+        ]
+    }
+]

--- a/transactions/set-candidate-limits/2023/nov-3/arguments-change-candidate-limits.json
+++ b/transactions/set-candidate-limits/2023/nov-3/arguments-change-candidate-limits.json
@@ -29,7 +29,7 @@
                 },
                 "value": {
                     "type": "UInt64",
-                    "value": "10"
+                    "value": "20"
                 }
             },
             {


### PR DESCRIPTION
Adds a template for updating the candidate node limits for each node type

I tested with a script on mainnet to confirm that it works properly and it passed