### PR TITLE
Adds epoch end staking transaction for Nov 7

### DIFF
--- a/templates/end-staking.cdc
+++ b/templates/end-staking.cdc
@@ -1,0 +1,11 @@
+import FlowEpoch from 0x8624b52f9ddcd04a
+import FlowIDTableStaking from 0x8624b52f9ddcd04a
+
+transaction {
+    prepare(signer: AuthAccount) {
+        let heartbeat = signer.borrow<&FlowEpoch.Heartbeat>(from: FlowEpoch.heartbeatStoragePath)
+            ?? panic("Could not borrow heartbeat from storage path")
+
+        heartbeat.endStakingAuction()
+    }
+}

--- a/transactions/end-staking/2023/nov-3/README.md
+++ b/transactions/end-staking/2023/nov-3/README.md
@@ -1,0 +1,33 @@
+# End Epoch Staking Auction
+
+> November 7, 2023
+
+## Transactions
+
+1. End the staking auction using the epoch smart contract
+
+`templates/end-staking.cdc`
+___
+
+# Transaction 1
+
+## Transaction 1 Sequence of signing: 
+
+Signer: Service account
+Transaction: `templates/end-staking.cdc`
+Gas limit: 1000000
+
+This transaction can be executed using the web tool.
+
+1. Flow generates the Signature Request ID on the [site](https://flow-multisig-git-service-account-onflow.vercel.app/mainnet?type=&name=&param=%5B%5D&acct=0x8624b52f9ddcd04a&limit=9999) for the `end-staking.cdc` transaction with the given args.
+
+2. Signers sign with the web tool or using flow cli specifying the Signature Request ID
+
+3. [Site](https://flow-multisig-git-service-account-onflow.vercel.app/mainnet) submits the transaction
+
+
+### Results
+
+Successful attempt:
+https://www.flowdiver.io/tx/
+___


### PR DESCRIPTION
Adds a transaction to end the staking auction with the epoch heartbeat resource, which also starts the epoch setup phase.

Also adds the README for the Nov 7th multisig transaction to end the staking auction before the nov 8th network upgrade