### PR TITLE
add transaction to set bonus token amount as part of burn

### DIFF
--- a/templates/set_bonus_tokens.cdc
+++ b/templates/set_bonus_tokens.cdc
@@ -1,0 +1,25 @@
+
+/// Saves an amount to storage that represent the amount
+/// of bonus tokens that have yet to be burned
+/// This amount is subtracted from the total supply of FLOW
+/// whenever a new total rewards amount is calculated every epoch
+/// because they are not meant to be a part of the total supply
+/// 
+/// Eventually, all bonus tokens will be burned and the amount will be zero
+///
+/// @param: bonusTokensBurned: the bonus tokens that were recently burned
+
+transaction(bonusTokensBurned: UFix64) {
+
+    prepare(signer: AuthAccount) {
+        let existingBonusAmount = signer.load<UFix64>(from: /storage/FlowBonusTokenAmount)
+            ?? panic("Could not load bonus token amount from storage")
+
+        assert(
+            existingBonusAmount >= bonusTokensBurned,
+            message: "Tokens burned cannot be greater than the existing amount!"
+        )
+
+        signer.save(existingBonusAmount - bonusTokensBurned, to: /storage/FlowBonusTokenAmount)
+    }
+}

--- a/transactions/burn-flow/2023/nov-10/README.md
+++ b/transactions/burn-flow/2023/nov-10/README.md
@@ -5,13 +5,27 @@ The Flow Service account will burn 9,792,568.00 FLOW
 are accounted for as part of the FlowToken.totalSupply but are *not considered* as part of
 the FlowToken inflation while paying rewards.
 
+The staking account also must update the record
+of bonus tokens that are used to calculate epoch rewards.
+
 ## About Bonus Tokens
 
 During the initial Flow launch two batches of tokens were created by the Gensis Account. These consisted of the initial Flow token supply and a second batch of 65mm tokens which are referred to as "Bonus Tokens." These 65mm tokens were withheld from the Flow Total Supply and distributed as locked tokens, only to be unlocked if the Flow mainnet launch milestones were NOT reached. "Bonus Tokens" were not considered included in "total supply" while calculating staking rewards. These milestones were all achieved, and the 65mm Bonus Tokens can now be destroyed. These locked tokens were not in circulation as they were not transferrable by the holding parties.
 
-## Transaction
+## Transaction 1
 
+Burns the tokens. Must be authorized by the service account.
 
 | Template                                                 | Arguments | Multisig Link   | Transaction |
 |---                                                       |---        |---              |---          |
 | [burn_flow.cdc](../../../../templates/burn_flow.cdc) | [arguments-burn-flow.json](./arguments-burn-flow.json) | [Burn Tokens](https://flow-multisig-git-service-account-onflow.vercel.app/mainnet?type=serviceAccount&name=burn_flow.cdc&param=%5B%20%20%20%20%20%7B%20%20%20%20%20%20%20%20%20%22type%22:%20%22UFix64%22,%20%20%20%20%20%20%20%20%20%22value%22:%20%229792568.00%22%20%20%20%20%20%7D%20%5D&acct=0xe467b9dd11fa00df&limit=9999) |
+
+
+## Transaction 2
+
+Sets the bonus token amount for the `FlowEpoch` smart contract.
+Must be signed by the staking account.
+
+| Template                                                 | Arguments | Multisig Link   | Transaction |
+|---                                                       |---        |---              |---          |
+| [set_bonus_tokens.cdc](../../../../templates/set_bonus_tokens.cdc) | [arguments-burn-flow.json](./arguments-burn-flow.json) | [Set Bonus Tokens Amount]() |


### PR DESCRIPTION
Adds the transaction that is used to set the bonus token amount that is used by the epoch contract to calculate rewards.
This transaction needs to be signed by the staking account and will be sent immediately after the burn tokens transaction succeeds