### PR TITLE
Apr 24 Transaction to remove old node

### DIFF
--- a/transactions/remove-approved-nodes/2024/Apr-24/README.md
+++ b/transactions/remove-approved-nodes/2024/Apr-24/README.md
@@ -1,0 +1,35 @@
+# Remove a decommissioned node from the Node Operators ID Table
+
+> April 24th, 2024
+
+Removing an old node ID that was not removed properly when it unstaked.
+
+`a3fac321587b4835966946cf7a13d5feaeb7ca91a84c85c2d2f861c2d80513ec`
+
+The `FlowIDTableStaking` contract was upgraded to have functionality to remove nodes
+from the approve list when they unstaked and also to unstaked and remove nodes 
+from the IDTable if they were removed from the approve list. 
+Because the upgrade was performed while this node was still approved but unstaked,
+it never went through the process of getting automatically removed from the approve list
+when it unstaked like nodes normally would. Therefore, it remains in the current
+list even though its stake is zero and its weight is zero.
+
+This transaction directly modifies the id table to remove the decommissioned node.
+The transaction contains proper checks to make sure only the provided node
+with zero weight is removed.
+
+The transaction must be authorized and signed with the staking account
+because it interacts with the staking account's storage.
+
+From now on, everything should be fine for cases where approved nodes unstaked.
+
+## Method using Multisign tool
+
+1. FF generates the Signature Request ID on the [site]() for the `remove_node_from_id_table.cdc` transaction signed by the staking account with the given args.
+
+2. Service account members sign and submit the transaction from the [site](https://flow-multisig-git-service-account-onflow.vercel.app/mainnet)
+
+
+## Results
+
+https://www.flowdiver.io/tx/

--- a/transactions/remove-approved-nodes/2024/Apr-24/arguments.json
+++ b/transactions/remove-approved-nodes/2024/Apr-24/arguments.json
@@ -1,0 +1,6 @@
+[
+    {
+        "type": "String",
+        "value": "a3fac321587b4835966946cf7a13d5feaeb7ca91a84c85c2d2f861c2d80513ec"
+    }
+]

--- a/transactions/remove-approved-nodes/2024/Apr-24/remove_node_from_id_table.cdc
+++ b/transactions/remove-approved-nodes/2024/Apr-24/remove_node_from_id_table.cdc
@@ -1,0 +1,54 @@
+import FlowIDTableStaking from 0x8624b52f9ddcd04a
+
+// This transaction removes a node ID from the current Identity table
+
+transaction(id: String) {
+
+    // Length of the ID Table Node list before the operation
+    // Used to verify that the id table was modified correctly
+    let lengthBefore: Int
+
+    prepare(acct: AuthAccount) {
+
+        // Load the current identity table from the storage of the staking account
+        // This is the only way to modify it without upgrading the staking contract
+        var list = acct.load<{String: Bool}>(from: /storage/idTableCurrentList)
+            ?? panic("Could not load current node list from storage")
+
+        self.lengthBefore = list.keys.length
+
+        // make sure that the provided ID is a node in the list
+        if list[id] == nil {
+            panic("Provided ID to remove does not exist in the ID Table")
+        }
+
+        let nodeInfo = FlowIDTableStaking.NodeInfo(nodeID: id)
+        assert(
+            nodeInfo.initialWeight == 0 && nodeInfo.tokensStaked == 0.0,
+            message: "The provided node ID should be in the ID table but have a weight and stake of zero"
+        )
+
+        // Remove the node ID
+        list.remove(key: id)
+
+        // Save the list back to storage
+        acct.save<{String: Bool}>(list, to: /storage/idTableCurrentList)
+    }
+
+    execute {
+        let newlist = FlowIDTableStaking.getParticipantNodeList()
+            ?? panic("Could not load the participant node list")
+
+        // Assert that the node has been removed
+        assert(
+            newlist[id] == nil,
+            message: "The node ID was not removed from the ID Table"
+        )
+
+        // Assert that only one node was removed
+        assert(
+            newlist.keys.length == self.lengthBefore - 1,
+            message: "Only one node should have been removed from the ID Table"
+        )
+    }
+}


### PR DESCRIPTION
Proposes a transaction to directly remove `a3fac321587b4835966946cf7a13d5feaeb7ca91a84c85c2d2f861c2d80513ec` from the identity table. More details are in the README