### PR TITLE
Adds tx to reset epoch for Epoch Fallback Mode

### DIFF
--- a/transactions/reset-epoch/2024/sept-11/README.md
+++ b/transactions/reset-epoch/2024/sept-11/README.md
@@ -1,0 +1,13 @@
+# Reset Epoch after EFM
+
+> Sept 11th, 2024
+
+The network went into Epoch Fallback mode because of an error in the system chunk.
+Epochs need to keep progressing, we we need to reset to the next epoch
+using the [ResetEpoch](../../../../templates/reset_epoch.cdc) transaction.
+
+[Site](https://flow-multisig-git-service-account-onflow.vercel.app/)
+
+## Results
+
+https://www.flowdiver.io/tx/

--- a/transactions/reset-epoch/2024/sept-11/arguments.json
+++ b/transactions/reset-epoch/2024/sept-11/arguments.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type":"UInt64",
+    "value":"144"
+  },
+  {
+    "type":"String",
+    "value":"f28339976b22b61917e69fb5eca9eeb8"
+  },
+  {
+    "type":"UInt64",
+    "value":"8000000"
+  },
+  {
+    "type":"UInt64",
+    "value":"200000000"
+  },
+  {
+    "type":"UInt64",
+    "value":"300000000"
+  }
+]


### PR DESCRIPTION
The network went into Epoch Fallback mode because of an error in the system chunk.
Epochs need to keep progressing, we we need to reset to the next epoch to keep rewards and epochs progressing.
This will pay rewards and move tokens like normal